### PR TITLE
feat: Add custom domain support for mantejsingh.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,15 @@ npm run dev  # Opens at http://localhost:5173
 
 ## ✨ **Key Features**
 
+### **Latest Release:**
+- **📱 Horizontal Carousel Navigation** - Mobile-only carousels for Work Experience, Skills & Technologies, and Featured Projects with smooth spring animations and desktop grid preservation
+
+### **Core Features:**
 - **🎯 Dynamic Work Experience Timeline** - Auto-calculates years worked with color-coded badges
 - **📊 Interactive Skills Visualization** - Realistic proficiency levels with animated progress bars  
 - **🎮 Smart Tooltip System** - Context-aware tooltips with randomized engaging messages
 - **⚡ Performance Optimized** - Code splitting, lazy loading, and PWA capabilities
-- **🎨 Advanced Animations** - DecryptedText, SpotlightCard, PrismBackground effects
+- **🎨 Advanced Animations** - DecryptedText, SpotlightCard, PrismBackground, TargetCursor effects
 - **📱 Responsive Design** - Mobile-first approach with touch-friendly interactions
 - **🌙 Dark/Light Theme** - System preference detection with manual toggle
 - **🔍 Type-Safe Development** - Full TypeScript implementation with strict typing

--- a/README.md
+++ b/README.md
@@ -302,13 +302,8 @@ This portfolio is designed for continuous evolution. Planned improvements includ
 - **Figma Community**: [figma.com/community/website-templates](https://www.figma.com/community/website-templates) - Website templates and UI kits
 - **React Bits Animations**: [reactbits.dev/animations](https://reactbits.dev/animations/) - Animation examples and inspiration
 
-### **Technical Resources**
-- **React 19.1**: [react.dev](https://react.dev) - Latest React with concurrent features
-- **shadcn/ui**: [ui.shadcn.com](https://ui.shadcn.com) - Component library and design system
-- **Tailwind CSS**: [tailwindcss.com](https://tailwindcss.com/docs) - Utility-first CSS framework
-- **Framer Motion**: [framer.com/docs](https://www.framer.com/docs/) - Production-ready motion library
-- **TypeScript**: [typescriptlang.org](https://www.typescriptlang.org) - Type-safe JavaScript
-
+> [!TIP]
+> **I relied on these heavily for any new feature or ideas**
 ---
 
 ## 🤝 **Contributing**

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+mantejsingh.dev

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,8 +13,8 @@ export default defineConfig(({ command }) => {
         "@": path.resolve(__dirname, "./src"),
       },
     },
-    // Configure base path: root for dev, subdirectory for production GitHub Pages
-    base: isProduction ? '/modern-portfolio-react/' : '/',
+    // Configure base path: root for custom domain
+    base: '/',
     build: {
       outDir: 'dist',
       assetsDir: 'assets',


### PR DESCRIPTION
## Summary
Configure repository for custom domain `mantejsingh.dev` hosted on Cloudflare.

## Changes Made
- ✅ **Add CNAME file**: Created `/public/CNAME` with `mantejsingh.dev`
- ✅ **Update build config**: Changed `vite.config.ts` base path from `/modern-portfolio-react/` to `/` for custom domain

## Technical Details
- Custom domain will serve from root path instead of subdirectory
- CNAME file tells GitHub Pages which domain to serve this repository for
- Base path change ensures all assets load correctly on custom domain

## Next Steps (After Merge)
- [ ] Configure Cloudflare DNS records
- [ ] Set up GitHub Pages custom domain setting
- [ ] Configure SSL/TLS in Cloudflare
- [ ] Test domain accessibility

## Related
Part of custom domain setup for professional portfolio branding.