### PR TITLE
quick fix: Removed unused isProduction variable

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,7 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => {
-  const isProduction = command === 'build'
-  
+export default defineConfig(() => {
   return {
     plugins: [react()],
     resolve: {


### PR DESCRIPTION
 - Removed unused isProduction variable and command parameter since we're now using a fixed base: '/'

📝 The Fix:

  - Before: export default defineConfig(({ command }) => { const isProduction = command === 'build'
  - After: export default defineConfig(() => {