### PR TITLE
fix: Update asset paths for custom domain

### DIFF
--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,10 +1,9 @@
 /**
  * Get the correct base path for assets based on environment
- * Development: /
- * Production: /modern-portfolio-react/
+ * Both development and production use root path for custom domain
  */
 export function getBasePath(): string {
-  return import.meta.env.DEV ? '/' : '/modern-portfolio-react/'
+  return '/'
 }
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,7 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => {
-  const isProduction = command === 'build'
-  
+export default defineConfig(() => {
   return {
     plugins: [react()],
     resolve: {


### PR DESCRIPTION
## Summary
Fix image loading issues on custom domain by updating asset path logic.

## Changes
- Update `getBasePath()` to use root path `/` for both dev and production
- Removes `/modern-portfolio-react/` subdirectory from asset URLs
- Fixes company logo display on mantejsingh.dev

## Before/After
- Before: `/modern-portfolio-react/images/VZ.png` (404 error)
- After: `/images/VZ.png` (loads correctly)
